### PR TITLE
Add NamedObjectRef resource to common API

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -105,3 +105,12 @@ func (t TypedObjectRef) ToCoreV1ObjectReference() *corev1.ObjectReference {
 func (t TypedObjectRef) String() string {
 	return fmt.Sprintf("%s: %s", t.GroupVersionKind(), t.ObjectKey())
 }
+
+// NamedObjectRef references an object by name and optionally by namespace.
+type NamedObjectRef struct {
+	// Name of the object. Required.
+	Name string `json:"name"`
+
+	// Namespace of the object. Optional. Defaulting behavior is determined by the parent API.
+	Namespace string `json:"namespace,omitempty"`
+}


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
This creates a resource that is referenced by name and optionally by namespace. If a namespace field isn't explicitly specified, a parent API is likely injecting the field into the resource and also handles the defaulting behavior of the field. This addresses the use case where a user-facing custom resource does not need to explicitly set a namespace and instead imports that field from a parent API. Previously, the user would have to still create a namespace field and set it to empty due to the namespace field being required by all existing common API resources. This object is comparable to the existing ObjectRef resource except for the fact that namespace is optional.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
